### PR TITLE
Remove deprecated `email` parameter in favor of `footer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub Profile Card](https://fancy-readme-stats.vercel.app/api?username=Gebuildet&show_icons=true&theme=forest_winter&email=luca@nextfight.net&description=UI/UX%20Designer%20and%20Frontend-Developer&include_all_commits=true)
+![GitHub Profile Card](https://fancy-readme-stats.vercel.app/api?username=Gebuildet&show_icons=true&theme=forest_winter&footer=luca@nextfight.net&description=UI/UX%20Designer%20and%20Frontend-Developer&include_all_commits=true)
 
 --- 
 


### PR DESCRIPTION
Hi!

I'm the maintainer of fancy-readme-stats and noticed you're using the deprecated `email` parameter which will be removed in future releases.

- Remove deprecated `email` parameter
- Use new `footer` URL parameter instead for future compatibility